### PR TITLE
Fix Google SERP variants without vt6azd class

### DIFF
--- a/serpinfo/google.yml
+++ b/serpinfo/google.yml
@@ -196,7 +196,7 @@ pages:
     userAgent: desktop
     results:
       - name: Default
-        root: .vt6azd:not(.g-blk)
+        root: ".vt6azd:not(.g-blk), .Ww4FFb:has(:is(.yuRUbf, .xe8e1b) a)"
         url: :is(.yuRUbf, .xe8e1b) a
         props:
           title: h3
@@ -269,7 +269,7 @@ pages:
     userAgent: mobile
     results:
       - name: Default
-        root: .vt6azd
+        root: '.vt6azd, .Ww4FFb:has(:is(.UBFage, a[role="presentation"]))'
         url: .UBFage, a[role="presentation"]
         props:
           title: '[role="heading"][aria-level="3"]'


### PR DESCRIPTION
<!--
Thank you for the contribution. Please review CONTRIBUTING.md in the main repo before submitting.
https://github.com/iorate/ublacklist/blob/master/CONTRIBUTING.md

New built-in SERPINFOs are not accepted (see CONTRIBUTING.md "No New Built-in SERPINFOs").

To add a new SearXNG instance, please submit a request to searxng/searx-instances instead. The list here is synced periodically.

Maintainers may skip or remove the checklist below.
-->

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/iorate/ublacklist/blob/master/CONTRIBUTING.md).
- [x] This is a trivial fix (typo fix, comment fix, minimal bug fix, fix to an existing built-in SERPINFO), or an issue is linked below.
- [x] This is not a new built-in SERPINFO.

### Linked issue

<!-- For a major change, link the issue (e.g. "Fixes iorate/ublacklist#123"). Trivial fixes may leave this empty. -->

 iorate/ublacklist#810

I intentionally kept the existing `.vt6azd` selector for a more conservative change.
It could probably be omitted if there are performance concerns.