### PR TITLE
duckduckgo: support Lite version

### DIFF
--- a/serpinfo/duckduckgo.yml
+++ b/serpinfo/duckduckgo.yml
@@ -88,3 +88,17 @@ pages:
         props:
           # Use ".result__a" instead of ".result__title", which has preceding whitespaces.
           title: .result__a
+
+  - name: Lite
+    matches:
+      - https://lite.duckduckgo.com/lite/
+      - https://lite.duckduckgo.com/lite/?*
+    commonProps:
+      $site: duckduckgo
+      $category: web
+    results:
+      - name: Default
+        root: tr
+        url: .result-link
+        props:
+          title: .result-link


### PR DESCRIPTION
Initial attempt at lite.duckduckgo.com filtering.

Each set of results on lite.duckduckgo.com is a quadruplet of `<tr>`.

I was able to target the link and title for each result within the first `<tr>` using `result-link` class.

But am not sure how to target additional `<tr>` containing `result-snippet` and `link-text` classes.

Here is an example of a DuckDuckGo Lite result:

```
<tr>
  <td valign="top"> 2.&nbsp; </td>
  <td>
    <a rel="nofollow" href="//duckduckgo.com/l/?uddg=http%3A%2F%2Flite.duckduckgo.com%2F" class='result-link'>DuckDuckGo</a>
  </td>
</tr>
<!-- Only show abstract separately if there's a click URL (not EOF) -->
<tr>
  <td>&nbsp;&nbsp;&nbsp;</td>
  <td class='result-snippet'> We would like to show you a description here but the site won&#x27;t allow us. </td>
</tr>
<tr>
  <td>&nbsp;&nbsp;&nbsp;</td>
  <td>
    <span class='link-text'>lite.duckduckgo.com</span>
  </td>
</tr>
<tr>
  <td>&nbsp;</td>
  <td>&nbsp;</td>
</tr>
```

<!--
Thank you for the contribution. Please review CONTRIBUTING.md in the main repo before submitting.
https://github.com/iorate/ublacklist/blob/master/CONTRIBUTING.md

New built-in SERPINFOs are not accepted (see CONTRIBUTING.md "No New Built-in SERPINFOs").

To add a new SearXNG instance, please submit a request to searxng/searx-instances instead. The list here is synced periodically.

Maintainers may skip or remove the checklist below.
-->

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/iorate/ublacklist/blob/master/CONTRIBUTING.md).
- [X] This is a trivial fix (typo fix, comment fix, minimal bug fix, fix to an existing built-in SERPINFO), or an issue is linked below.
- [X] This is not a new built-in SERPINFO.

### Linked issue

<!-- For a major change, link the issue (e.g. "Fixes iorate/ublacklist#123"). Trivial fixes may leave this empty. -->
