### PR TITLE
Run lefthook pre-commit jobs serially to avoid pnpm deps-check race

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,10 +1,10 @@
 pre-commit:
-  parallel: true
-  commands:
-    biome:
+  # Run serially: parallel `pnpm` invocations race on pnpm's deps-status check.
+  jobs:
+    - name: biome
       run: pnpm biome check --write --files-ignore-unknown=true --no-errors-on-unmatched {staged_files}
       stage_fixed: true
-    prettier:
+    - name: prettier
       glob: "*.{md,yaml,yml}"
       run: pnpm prettier --write {staged_files}
       stage_fixed: true


### PR DESCRIPTION
Switches lefthook's pre-commit from parallel `commands` to serial `jobs`, matching iorate/ublacklist. Parallel `pnpm` invocations race on pnpm's deps-status check, which can break commits locally.